### PR TITLE
Put context parameter first.

### DIFF
--- a/context.go
+++ b/context.go
@@ -10,17 +10,17 @@ import "context"
 // The returned context must be cancelled when done similar to
 // https://golang.org/pkg/context/#WithCancel
 func CancelCtx(parent context.Context) (ctx context.Context, cancel context.CancelFunc) {
-	return cancelContext(StagePS, parent)
+	return cancelContext(parent, StagePS)
 }
 
 // CancelCtxN will cancel the supplied context at a supplied shutdown stage.
 // The returned context must be cancelled when done similar to
 // https://golang.org/pkg/context/#WithCancel
-func CancelCtxN(s Stage, parent context.Context) (ctx context.Context, cancel context.CancelFunc) {
-	return cancelContext(s, parent)
+func CancelCtxN(parent context.Context, s Stage) (ctx context.Context, cancel context.CancelFunc) {
+	return cancelContext(parent, s)
 }
 
-func cancelContext(s Stage, parent context.Context) (ctx context.Context, cancel context.CancelFunc) {
+func cancelContext(parent context.Context, s Stage) (ctx context.Context, cancel context.CancelFunc) {
 	ctx, cancel = context.WithCancel(parent)
 	f := onShutdown(s.n, 2, []interface{}{parent}).n
 	go func() {

--- a/context_test.go
+++ b/context_test.go
@@ -75,7 +75,7 @@ func TestCancelCtxN(t *testing.T) {
 	contexts := []context.Context{}
 
 	for _, stage := range stages {
-		c1, cc := CancelCtxN(stage, context.Background())
+		c1, cc := CancelCtxN(context.Background(), stage)
 		defer cc()
 		if got, want := fmt.Sprint(c1), "context.Background.WithCancel"; got != want {
 			t.Errorf("c1.String() = %q want %q", got, want)
@@ -124,7 +124,7 @@ func TestCancelCtxNShutdown(t *testing.T) {
 	contexts := []context.Context{}
 
 	for _, stage := range stages {
-		c1, cancel1 := CancelCtxN(stage, context.Background())
+		c1, cancel1 := CancelCtxN(context.Background(), stage)
 		o := otherContext{c1}
 		c2, cc := context.WithCancel(o)
 		defer cc()
@@ -189,8 +189,8 @@ func TestCancelCtxX(t *testing.T) {
 		default:
 			t.Errorf("<-c[%d].Done() blocked, but shouldn't have", i)
 		}
-		if e := c.Err(); e != xcontext.Canceled {
-			t.Errorf("c[%d].Err() == %v want %v", i, e, xcontext.Canceled)
+		if e := c.Err(); e != context.Canceled {
+			t.Errorf("c[%d].Err() == %#v want %#v", i, e, context.Canceled)
 		}
 	}
 }

--- a/context_x.go
+++ b/context_x.go
@@ -12,17 +12,17 @@ import "golang.org/x/net/context"
 // The returned context must be cancelled when done similar to
 // https://golang.org/pkg/context/#WithCancel
 func CancelCtx(parent context.Context) (ctx context.Context, cancel context.CancelFunc) {
-	return cancelContext(StagePS, parent)
+	return cancelContext(parent, StagePS)
 }
 
 // CancelCtxN will cancel the supplied context at a supplied shutdown stage.
 // The returned context must be cancelled when done similar to
 // https://golang.org/pkg/context/#WithCancel
-func CancelCtxN(s Stage, parent context.Context) (ctx context.Context, cancel context.CancelFunc) {
-	return cancelContext(s, parent)
+func CancelCtxN(parent context.Context, s Stage) (ctx context.Context, cancel context.CancelFunc) {
+	return cancelContext(parent, s)
 }
 
-func cancelContext(s Stage, parent context.Context) (ctx context.Context, cancel context.CancelFunc) {
+func cancelContext(parent context.Context, s Stage) (ctx context.Context, cancel context.CancelFunc) {
 	ctx, cancel = context.WithCancel(parent)
 	f := onShutdown(s.n, 2, []interface{}{parent}).n
 	go func() {

--- a/context_x_test.go
+++ b/context_x_test.go
@@ -72,7 +72,7 @@ func TestCancelCtxN(t *testing.T) {
 	contexts := []context.Context{}
 
 	for _, stage := range stages {
-		c1, _ := CancelCtxN(stage, context.Background())
+		c1, _ := CancelCtxN(context.Background(), stage)
 		if got, want := fmt.Sprint(c1), "context.Background.WithCancel"; got != want {
 			t.Errorf("c1.String() = %q want %q", got, want)
 		}
@@ -119,7 +119,7 @@ func TestCancelCtxNShutdown(t *testing.T) {
 	contexts := []context.Context{}
 
 	for _, stage := range stages {
-		c1, cancel1 := CancelCtxN(stage, context.Background())
+		c1, cancel1 := CancelCtxN(context.Background(), stage)
 		o := otherContext{c1}
 		c2, _ := context.WithCancel(o)
 		contexts = append(contexts, c1, o, c2)


### PR DESCRIPTION
BREAKING CHANGE, but context is rather new.