### PR TITLE
Return a nil notifier if shutdown already started

### DIFF
--- a/context.go
+++ b/context.go
@@ -23,6 +23,10 @@ func CancelCtxN(parent context.Context, s Stage) (ctx context.Context, cancel co
 func cancelContext(parent context.Context, s Stage) (ctx context.Context, cancel context.CancelFunc) {
 	ctx, cancel = context.WithCancel(parent)
 	f := onShutdown(s.n, 2, []interface{}{parent}).n
+	if f == nil {
+		cancel()
+		return ctx, cancel
+	}
 	go func() {
 		select {
 		case <-ctx.Done():

--- a/context_x.go
+++ b/context_x.go
@@ -25,6 +25,10 @@ func CancelCtxN(parent context.Context, s Stage) (ctx context.Context, cancel co
 func cancelContext(parent context.Context, s Stage) (ctx context.Context, cancel context.CancelFunc) {
 	ctx, cancel = context.WithCancel(parent)
 	f := onShutdown(s.n, 2, []interface{}{parent}).n
+	if f == nil {
+		cancel()
+		return ctx, cancel
+	}
 	go func() {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
It was tricky to detect cases where shutdown had started when you requested notifiers.

To help for that common case, the library now **returns a nil Notifier** if shutdown has already
reached the stage you are requesting a notifier for.

This is backwards compatible, but makes it much easier to test for such a case.