### PR TITLE
Add a function similar to Started that returns a channel

### DIFF
--- a/shutdown.go
+++ b/shutdown.go
@@ -396,10 +396,9 @@ func Shutdown() {
 		// Wait till shutdown finished
 		<-shutdownFinished
 		return
-	} else {
-		close(shutdownRequestedCh)
 	}
 	shutdownRequested = true
+	close(shutdownRequestedCh)
 	lwg := wg
 	onTimeOutFn := onTimeOut
 	srM.Unlock()

--- a/shutdown.go
+++ b/shutdown.go
@@ -396,9 +396,10 @@ func Shutdown() {
 		// Wait till shutdown finished
 		<-shutdownFinished
 		return
+	} else {
+		close(shutdownRequestedCh)
 	}
 	shutdownRequested = true
-	close(shutdownRequestedCh)
 	lwg := wg
 	onTimeOutFn := onTimeOut
 	srM.Unlock()

--- a/shutdown_test.go
+++ b/shutdown_test.go
@@ -25,6 +25,7 @@ func reset() {
 	defer srM.Unlock()
 	wg = &sync.WaitGroup{}
 	shutdownRequested = false
+	shutdownRequestedCh = make(chan struct{})
 	shutdownQueue = [4][]iNotifier{}
 	shutdownFnQueue = [4][]fnNotify{}
 	shutdownFinished = make(chan struct{})


### PR DESCRIPTION
Added new `StartedCh` function that returns a channel that gets closed once shutdown starts. It works in a was similar to `Started` function.

```go
// Started
for !shutdown.Started() {
    process()
}

// StartedCh
for {
    select {
    case val := <-dataCh:
        process(val)
    case <-shutdown.StartedCh():
        return
    }
}
```